### PR TITLE
Re-enable nogui build

### DIFF
--- a/org.duckstation.DuckStation.yml
+++ b/org.duckstation.DuckStation.yml
@@ -53,8 +53,10 @@ modules:
       - -DUSE_X11=ON
       - -DUSE_DRMKMS=ON
       - -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+      - -DBUILD_NOGUI_FRONTEND=ON
     post-install:
       - install -m755 bin/duckstation-qt /app/bin
+      - install -m755 bin/duckstation-nogui /app/bin
       - |-
         for image in ../*px.png; do
           icon=${image%px*}


### PR DESCRIPTION
This should not cause a substantial increase in flatpak build time, but would be nice for the reason outlined in #21.