### PR TITLE
Remove wayland socket to prevent game list background flickering

### DIFF
--- a/org.duckstation.DuckStation.json
+++ b/org.duckstation.DuckStation.json
@@ -12,8 +12,7 @@
     "--allow=bluetooth",
     "--share=network",
     "--share=ipc",
-    "--socket=fallback-x11",
-    "--socket=wayland",
+    "--socket=x11",
     "--socket=pulseaudio",
     "--talk-name=org.freedesktop.ScreenSaver"
   ],


### PR DESCRIPTION
After upgrading from the unofficial flatpak to the official flatpak, the list of games now flickers after loading a savestate in a game (Crash Bandicoot in this case), behind the game itself. I fixed this locally by disabling the wayland socket via flatseal, forcing the emulator to run in Xwayland. This is on KDE wayland session.