### PR TITLE
Upgrade runtime to 6.6 and LLVM 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The `flatpak-builder` package is required.
 
 - Install the SDK
 
-`flatpak install org.kde.Platform/x86_64/6.5 org.kde.Sdk/x86_64/6.5 org.freedesktop.Sdk.Extension.llvm16`
+`flatpak install org.kde.Platform/x86_64/6.6 org.kde.Sdk/x86_64/6.6 org.freedesktop.Sdk.Extension.llvm17`
 
 - Build DuckStation
 

--- a/org.duckstation.DuckStation.json
+++ b/org.duckstation.DuckStation.json
@@ -1,10 +1,10 @@
 {
   "app-id": "org.duckstation.DuckStation",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.5",
+  "runtime-version": "6.6",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.llvm16"
+    "org.freedesktop.Sdk.Extension.llvm17"
   ],
   "command": "duckstation-qt",
   "finish-args": [


### PR DESCRIPTION
May not be ready to merge yet, depending on the upstream project support of Qt 6.6 and LLVM 17.
The 6.6 runtime notably updates Mesa from 23.1.9 to 23.2.1.